### PR TITLE
#88/disable google analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ highlighter: rouge
 paginate: 20
 baseurl: /
 domain_name: 'www.codeandcoffeelb.org'
-google_analytics: 'UA-68278840-1'
+# google_analytics: 'UA-68278840-1'
 disqus: false
 disqus_shortname: 'your-disqus-shortname'
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
   <script src="{{ site.baseurl }}assets/js/highlight.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
 
-  <script>
+<!--   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -42,7 +42,7 @@
 
     ga('create', '{{ site.google_analytics }}', 'auto');
     ga('send', 'pageview');
-  </script>
+  </script> -->
 </body>
 </html>
 


### PR DESCRIPTION
This PR disables Google Analytics as it is currently using a GA code in @rogerhoward’s Google account that will be deactivated soon.

Ideally, someone should just create a new GA code, add it to _config.yml, and re-enable.