### PR TITLE
fix(_includes): update navigation per Jekyll tutorial

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,12 @@
+navigation_items:
+  - title: about
+    path: about
+
+  - title: members
+    path: members
+
+  - title: challenges
+    path: challenges
+
+  - title: conduct
+    path: conduct

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,24 +1,10 @@
 <nav class="main-nav">
-    {% if page.url != "/index.html" %}
-        <a href="{{ site.baseurl }}" class="text--black"> <span class="arrow">←</span> home </a>
+    {% if page.url != "/" %}
+        <a href="/" class="text--black"><span class="arrow">←</span>home</a>
     {% endif %}
-
-    {% if page.url != "/about/" %}
-        {% if site.aboutPage %}
-            <a href="{{ site.baseurl }}about" class="text--black">about </a>
-        {% endif %}
-    {% endif %}
-
-    {% if page.url != "/members/" %}
-            <a href="/members/" class="text--black">members </a>
-    {% endif %}
-
-    {% if page.url != "/challenges/" %}
-            <a href="/challenges/" class="text--black">challenges </a>
-    {% endif %}
-
-    {% if page.url != "/conduct/" %}
-            <a href="/conduct/" class="text--black">conduct </a>
-    {% endif %}
-
+    {% for navigation_item in site.data.navigation.navigation_items %}
+        <a href="{{ site.baseurl | append: navigation_item.path }}" class="text--black">
+            {{ navigation_item.title }}
+        </a>
+    {% endfor %}
 </nav>


### PR DESCRIPTION
Closes https://github.com/codeandcoffeelb/codeandcoffeelb.github.io/issues/95.

### Summary

👋 Hello, codeandcoffeelb! I know @karimamer is assigned to the original issue, so I'm happy to yield to their changes and you're more than welcome to close this out.

#### Approach

This is my take drawing from the approach recommended in https://jekyllrb.com/tutorials/navigation/:

* creates a YAML file in the `_data` defining the navigation items
* updates `includes/navigation.html` to use one conditional to omit the home page at root and a `for` iterator to render all navigation items

I tested my changes locally by spinning up the `Dockerfile` defined in this repo to ensure what I've proposed is functional. Here's a motion picture, if it helps!

![new-navigation-walkthrough](https://user-images.githubusercontent.com/15894826/72322844-31e1e380-365c-11ea-9842-5ff47adc2137.gif)


#### Next steps

Requesting review from @davidnuon as the maintainer of this organization (please correct me if I'm wrong 🙇 ). I've allowed edits from maintainers in the case there's anything you'd like to modify. I'm open to receive any feedback about my implementation––I'm not tied down to anything in particular.  Ultimately, I'd just like to see Navigation fixed for your site! 😎 